### PR TITLE
Adding a flag to have the option of chosing runtime for k8s cluster

### DIFF
--- a/pkg/providers/common/provider.go
+++ b/pkg/providers/common/provider.go
@@ -33,6 +33,9 @@ func (p *Provider) BindFlags(flags *pflag.FlagSet) {
 		&p.BuildVersion, "build-version", "", "Kubernetes Build Version",
 	)
 	flags.StringVar(
+		&p.Runtime, "runtime", "", "Runtime used while installing k8s cluster",
+	)
+	flags.StringVar(
 		&p.StorageServer, "s3-server", "", "S3 server where Kubernees Bits are stored",
 	)
 	flags.StringVar(

--- a/pkg/tfvars/tfvars.go
+++ b/pkg/tfvars/tfvars.go
@@ -3,6 +3,7 @@ package tfvars
 type TFVars struct {
 	ReleaseMarker  string `json:"release_marker"`
 	BuildVersion   string `json:"build_version"`
+	Runtime        string `json:"runtime,omitempty"`
 	StorageServer  string `json:"s3_server,omitempty"`
 	StorageBucket  string `json:"bucket,omitempty"`
 	StorageDir     string `json:"directory,omitempty"`


### PR DESCRIPTION
This addition is part of the story https://github.ibm.com/powercloud/container-dev/issues/1353

Need "runtime" flag in kubetest2 to pass the choice of runtime(docker/containerd as of now) to the k8s-ansible sub-module it uses to build the test cluster.
