### PR TITLE
Fix the Conditional logic for ansible Playbook function

### DIFF
--- a/pkg/ansible/ansible.go
+++ b/pkg/ansible/ansible.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	ansibleDataDir = "k8s-ansible"
+	ansibleDataDir    = "k8s-ansible"
 )
 
 func Playbook(dir, inventory, extraVars, playbook string) (int, error) {
@@ -30,11 +30,17 @@ func Playbook(dir, inventory, extraVars, playbook string) (int, error) {
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 	if err := c.Run(); err != nil {
+		// Try to get the exit code
 		if exitError, ok := err.(*goexec.ExitError); ok {
 			return exitError.ExitCode(), err
+		} else {
+			// This will happen if ansible is not available in $PATH
+			return 1, err
 		}
+	} else {
+		// successful execution of ansible playbook
+		return 0, nil
 	}
-	return 0, nil
 }
 
 func unpackAnsible(dir string) error {


### PR DESCRIPTION
The current logic doesn't capture the Error when ansible isn't available in the `$PATH` from where the playbook/kubetest2 command is run.
The following error goes unnoticed
```
exec: "ansible-playbook": executable file not found in `$PATH`
```
The `Playbook` func from pkg/ansible/ansible.go is returning a nil error and hence the kubetest2 deployer is proceeding further looking for kubeconfig. Thus the below **wrong error message**:
```
Error: failed to setKubeconfig: failed to locate the kubeconfig file: stat /root/kubetest2-plugins/ragni-wed2-vm/kubeconfig: no such file or directory
```
as mentioned by @RagniGarg97 in below comment.
https://github.ibm.com/powercloud/container-dev/issues/1452#issuecomment-29386246
