### PR TITLE
Fix the terraform destroy failure with kubetest2-tf

### DIFF
--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -47,8 +47,6 @@ func Destroy(dir string, platform string, autoApprove bool, extraArgs ...string)
 		"-input=false",
 		fmt.Sprintf("-state=%s", filepath.Join(dir, StateFileName)),
 		fmt.Sprintf("-state-out=%s", filepath.Join(dir, StateFileName)),
-		fmt.Sprintf("-var-file=%s", filepath.Join(dir, platform+".auto.tfvars.json")),
-		fmt.Sprintf("-var-file=%s", filepath.Join(dir, "common.auto.tfvars.json")),
 	}
 	if autoApprove {
 		defaultArgs = append(defaultArgs, "-auto-approve")


### PR DESCRIPTION
@mkumatag This would probably fix https://github.ibm.com/powercloud/container-dev/issues/1584

To verify this, I am unable to do a `test-pj` with this change due to the unavailability of my x86 VM on Fyre. There is some Maintenance work on Fyre.
Also `test-pj` has trouble running from my windows desktop.
If needed, in my absence, can you or @amulmek1 Amulya please verify if https://github.com/ppc64le-cloud/test-infra/blob/master/config/jobs/periodic/kubernetes/test-kubernetes-periodics.yaml#L42 is successful with this change?

