### PR TITLE
Check for package dependencies in the environment before test-execution

### DIFF
--- a/kubetest2-tf/deployer/deployer.go
+++ b/kubetest2-tf/deployer/deployer.go
@@ -3,6 +3,17 @@ package deployer
 import (
 	"encoding/json"
 	"fmt"
+	"log"
+	"net"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"text/template"
+
 	"github.com/ppc64le-cloud/kubetest2-plugins/pkg/ansible"
 	"github.com/ppc64le-cloud/kubetest2-plugins/pkg/providers"
 	"github.com/ppc64le-cloud/kubetest2-plugins/pkg/providers/common"
@@ -11,16 +22,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
-	"log"
-	"net"
-	"net/url"
-	"os"
-	"path/filepath"
-	"reflect"
 	"sigs.k8s.io/kubetest2/pkg/types"
-	"strings"
-	"sync"
-	"text/template"
 )
 
 const (
@@ -38,6 +40,8 @@ type AnsibleInventory struct {
 	Masters []string
 	Workers []string
 }
+
+var dependencies = []string{"terraform", "ansible"} // Add additional Linux package dependencies here, used by checkDependencies()
 
 func (i *AnsibleInventory) addMachine(mtype string, value string) {
 	v := reflect.ValueOf(i).Elem().FieldByName(mtype)
@@ -61,6 +65,10 @@ func (d *deployer) init() error {
 }
 
 func (d *deployer) initialize() error {
+	fmt.Println("Check if package dependencies are installed in the environment")
+	if err := d.checkDependencies(); err != nil {
+		return err
+	}
 	d.provider = powervs.PowerVSProvider
 	common.CommonProvider.Initialize()
 	d.tmpDir = common.CommonProvider.ClusterName
@@ -83,7 +91,7 @@ var (
 	retryOnTfFailure      int
 	breakKubetestOnUpFail bool
 	playbook              string
-	extraVars map[string]string
+	extraVars             map[string]string
 )
 
 func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
@@ -284,4 +292,15 @@ func (d *deployer) DumpClusterLogs() error {
 
 func (d *deployer) Build() error {
 	panic("implement me")
+}
+
+// checkDependencies determines if the required packages are installed before
+// the test execution begins, providing a fail-fast route for exit if the packages are not found.
+func (d *deployer) checkDependencies() error {
+	for _, dependency := range dependencies {
+		if _, err := exec.LookPath(dependency); err != nil {
+			return fmt.Errorf("failed to find %s in the test environment: %s", dependency, err)
+		}
+	}
+	return nil
 }

--- a/kubetest2-tf/deployer/deployer.go
+++ b/kubetest2-tf/deployer/deployer.go
@@ -14,15 +14,17 @@ import (
 	"sync"
 	"text/template"
 
+	"github.com/spf13/pflag"
+
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/kubetest2/pkg/types"
+	
 	"github.com/ppc64le-cloud/kubetest2-plugins/pkg/ansible"
 	"github.com/ppc64le-cloud/kubetest2-plugins/pkg/providers"
 	"github.com/ppc64le-cloud/kubetest2-plugins/pkg/providers/common"
 	"github.com/ppc64le-cloud/kubetest2-plugins/pkg/providers/powervs"
 	"github.com/ppc64le-cloud/kubetest2-plugins/pkg/terraform"
-	"github.com/spf13/pflag"
-	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog/v2"
-	"sigs.k8s.io/kubetest2/pkg/types"
 )
 
 const (
@@ -41,7 +43,8 @@ type AnsibleInventory struct {
 	Workers []string
 }
 
-var dependencies = []string{"terraform", "ansible"} // Add additional Linux package dependencies here, used by checkDependencies()
+// Add additional Linux package dependencies here, used by checkDependencies()
+var dependencies = []string{"terraform", "ansible"}
 
 func (i *AnsibleInventory) addMachine(mtype string, value string) {
 	v := reflect.ValueOf(i).Elem().FieldByName(mtype)


### PR DESCRIPTION
Purpose: 
The changes are aimed at capturing test-environment level dependencies that may not be installed, leading un-captured/incorrect errors, or failures at a later stage. 

This fix aims at an early-exit if the modules are not found and return the error related to the missing packages. In case of ansible, the test would fail at a stage after terraform provisions the VMs for cluster creation.


Background:
Error reported before fix in case if terraform is not installed in the test environment - 
```
terraform.Output:
terraform.Output error: <nil>
Terraform State at: perf-tester/terraform.tfstate
I0926 21:48:45.428987  139163 deployer.go:177] masters:
Error: failed to unmarshal: unexpected end of JSON input
```

Error to be reported post merge.
Missing terraform
```
Check if package dependencies are installed
Error: up failed to init: failed to find terraform in the test environment: exec: "terraform": executable file not found in $PATH
```
Missing ansible
```
Check if package dependencies are installed
Error: up failed to init: failed to find ansible in the test environment: exec: "ansible": executable file not found in $PATH
```






