### PR TITLE
Use the version defined in go.mod for GitHub Actions.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,9 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version-file: 'go.mod'
+        cache: true
+        cache-dependency-path: go.sum
 
     - name: Build
       run: go build -v ./...


### PR DESCRIPTION
Fixes: #74 

Changes in this PR:
1. Use the version defined in the go.mod file for GitHub actions for Go, involving build and test.
2. Enable caching in actions/setup-go, for quicker builds.
