### PR TITLE
Add GitTag and Version to deployer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+# Common uses:
+# installing a kubetest2-tf deployer: `make install-deployer-tf INSTALL_DIR=$HOME/go/bin`
+
+# get the repo root and output path
+REPO_ROOT:=$(shell pwd)
+export REPO_ROOT
+OUT_DIR=$(REPO_ROOT)/bin
+# record the source commit in the binary, overridable
+COMMIT?=$(shell git describe --tags --always 2>/dev/null)
+INSTALL?=install
+# make install will place binaries here
+# the default path attempts to mimic go install
+INSTALL_DIR?=$(shell $(REPO_ROOT)/hack/goinstalldir.sh)
+# the output binary name, overridden when cross compiling
+BINARY_NAME=kubetest2-tf
+BINARY_PATH=./kubetest2-tf
+BUILD_FLAGS=-trimpath -ldflags="-buildid= -X=github.com/ppc64le-cloud/kubetest2-plugins/kubetest2-tf/deployer.GitTag=$(COMMIT)"
+# ==============================================================================
+
+install-deployer-tf:
+	go build -v $(BUILD_FLAGS) -o $(OUT_DIR)/$(BINARY_NAME) $(BINARY_PATH)
+	$(INSTALL) -d $(INSTALL_DIR)
+	$(INSTALL) $(OUT_DIR)/$(BINARY_NAME) $(INSTALL_DIR)/$(BINARY_NAME)
+.PHONY: install-deployer-tf

--- a/hack/goinstalldir.sh
+++ b/hack/goinstalldir.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# This utility prints out the golang install dir, even if go is not installed
+# IE it prints the directory where `go install ...` would theoretically place
+# binaries
+
+# if we have go, just ask go!
+if which go >/dev/null 2>&1; then
+  DIR=$(go env GOBIN)
+  if [ -n "${DIR}" ]; then
+    echo "${DIR}"
+    exit 0
+  fi
+  DIR=$(go env GOPATH)
+  if [ -n "${DIR}" ]; then
+    echo "${DIR}/bin"
+    exit 0
+  fi
+fi
+
+# mimic go behavior
+
+# check if GOBIN is set anyhow
+if [ -n "${GOBIN}" ]; then
+  echo "GOBIN"
+  exit 0
+fi
+
+# check if GOPATH is set anyhow
+if [ -n "${GOPATH}" ]; then
+  echo "${GOPATH}/bin"
+  exit 0
+fi
+
+# finally use default for no $GOPATH or $GOBIN
+echo "${HOME}/go/bin"

--- a/kubetest2-tf/deployer/deployer.go
+++ b/kubetest2-tf/deployer/deployer.go
@@ -38,6 +38,8 @@ const (
 `
 )
 
+var GitTag string
+
 type AnsibleInventory struct {
 	Masters []string
 	Workers []string
@@ -59,6 +61,10 @@ type deployer struct {
 	doInit        sync.Once
 	tmpDir        string
 	provider      providers.Provider
+}
+
+func (d *deployer) Version() string {
+	return GitTag
 }
 
 func (d *deployer) init() error {


### PR DESCRIPTION
The variable `GitTag` and function `Version` is needed for displaying key and value for `deployer-version` in metadata.json
Ref: https://github.com/kubernetes-sigs/kubetest2/blob/master/pkg/app/app.go#L223
https://github.com/kubernetes-sigs/kubetest2/blob/master/kubetest2-kind/deployer/deployer.go#L77