### PR TITLE
Introduce storage tier variable set to tier-1 by default

### DIFF
--- a/data/powervs/instance/main.tf
+++ b/data/powervs/instance/main.tf
@@ -17,6 +17,7 @@ resource "ibm_pi_instance" "pvminstance" {
     pi_image_id           = data.ibm_pi_image.power_images.id
     pi_key_pair_name      = var.ssh_key_name
     pi_sys_type           = var.system_type
+    pi_storage_type       = var.storage_tier
     pi_cloud_instance_id = var.powervs_service_instance_id
     pi_user_data          = var.user_data
     # Wait for the WARNING state instead of OK state to save some time because we aren't performing any DLPAR operations

--- a/data/powervs/instance/variables.tf
+++ b/data/powervs/instance/variables.tf
@@ -50,6 +50,11 @@ variable "system_type" {
     default     = "s922"
 }
 
+variable "storage_tier" {
+    description = "I/O operation per second (IOPS) based storage on requirement - tier1, tier3 "
+    default     = "tier1"
+}
+
 variable "image_name" {
     description = "Name of the image from which the VM should be deployed - IBM i image name"
 }


### PR DESCRIPTION
Observed that the storage-tier used in the periodic jobs is `tier-3`, which compromises on IO.
Setting the same to `tier1` for improved performance.

Validated the changes with an end-to-end test.
```
  + resource "ibm_pi_instance" "pvminstance" {
...
      + pi_storage_type                = "tier1"
      + pi_sys_type                    = "s922"
...
 ```