### PR TITLE
Add timeouts value for create and delete of instance

### DIFF
--- a/data/powervs/instance/main.tf
+++ b/data/powervs/instance/main.tf
@@ -27,4 +27,8 @@ resource "ibm_pi_instance" "pvminstance" {
     pi_network {
       network_id = data.ibm_pi_network.power_network.id
     }
+    timeouts {
+      create = "30m"
+      delete = "30m"
+    }
 }


### PR DESCRIPTION
The default timeout from IBM terraform provider for create is 120minutes.
Ref: https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/pi_instance#timeouts
This is causing stale resources as job is exiting without running the --down flag of kubetest2 tf command.

This change makes the wait time 30mins for create and delete vm actions.

I have manually verified if these values are being picked up.