### PR TITLE
DumpClusterLogs + IsUp implementation for kubetest2. 

### DIFF
--- a/kubetest2-tf/deployer/dumplogs.go
+++ b/kubetest2-tf/deployer/dumplogs.go
@@ -1,0 +1,47 @@
+package deployer
+
+import (
+	"fmt"
+	"k8s.io/klog/v2"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func (d *deployer) DumpClusterLogs() error {
+	klog.Infof("Collecting cluster logs under %s", d.logsDir)
+	// create a directory based on the generated path: _rundir/dump-cluster-logs
+	if _, err := os.Stat(d.logsDir); os.IsNotExist(err) {
+		if err := os.Mkdir(d.logsDir, os.ModePerm); err != nil {
+			klog.Errorf("cannot create a directory in path %q. Err: %v", d.logsDir, err)
+			return err
+		}
+	} else if err == nil {
+		klog.Errorf("%q already exists. Please clean up directory", d.logsDir)
+		return err
+	} else {
+		return fmt.Errorf("an error occured while obtaining directory stats. Err: %v", err)
+	}
+	outfile, err := os.Create(filepath.Join(d.logsDir, "cluster-info.log"))
+	if err != nil {
+		klog.Errorf("Failed to create a log file. Err: %v", err)
+		return err
+	}
+	defer outfile.Close()
+	command := []string{
+		"kubectl",
+		"cluster-info",
+		"dump",
+	}
+	klog.Infof("About to run: %s", command)
+	cmd := exec.Command(command[0], command[1:]...)
+	cmd.Stdout = outfile
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("couldn't use kubectl to dump cluster info: %s", err)
+	}
+	klog.Infof("Executed %s successfully", command)
+	// Todo: Include provider specific logic in this section. (Includes node level information/CRI/Services, etc.)
+	return nil
+}


### PR DESCRIPTION
Tested locally and with an e2e flow. Barebones implementation to retrieve basic cluster information after the cluster is spun up, along the lines of other deployer implementations.

```
I1030 13:36:47.413868   96599 deployer.go:327] About to run: [kubectl get nodes -o=name]
I1030 13:36:48.185794   96599 deployer.go:264] Dumping cluster info..
I1030 13:36:48.185827   96599 dumplogs.go:12] Collecting cluster logs under /Users/kishenv/github.com/kubetest2-plugins/bin/_rundir/ab87f950-7ff6-41d5-845a-db6a8c3d1f86/logs
I1030 13:36:48.186027   96599 dumplogs.go:36] About to run: [kubectl cluster-info dump]
I1030 13:36:48.397743   96599 dumplogs.go:44] Executed [kubectl cluster-info dump] successfully
```