### PR TITLE
Add --stage to accept Directory input in cos bucket

### DIFF
--- a/pkg/build/stage-ibmcos.go
+++ b/pkg/build/stage-ibmcos.go
@@ -21,6 +21,7 @@ type IBMCOSStager struct {
 	RepoRoot        string
 	Region          string
 	Bucket          string
+	Path            string
 	TargetBuildArch string
 }
 
@@ -36,6 +37,7 @@ func NewIBMCOSStager(stageLocation, repoRoot, targetBuildArch string) (*IBMCOSSt
 		RepoRoot:        repoRoot,
 		Region:          matches[2],
 		Bucket:          matches[3],
+		Path:            matches[4],
 		TargetBuildArch: targetBuildArch,
 	}, nil
 }
@@ -57,8 +59,8 @@ func (i *IBMCOSStager) getS3Client() *s3.S3 {
 func (i *IBMCOSStager) Stage(version string) error {
 	client := i.getS3Client()
 	tgzFile := "kubernetes-server-" + strings.ReplaceAll(i.TargetBuildArch, "/", "-") + ".tar.gz"
-	destinationKey := aws.String(version + "/" + tgzFile)
-	klog.Infof("uploading %s to location %s/%s", tgzFile, i.StageLocation, *destinationKey)
+	destinationKey := aws.String(i.Path + "/" + version + "/" + tgzFile)
+	klog.Infof("uploading %s to location %s/%s", tgzFile, i.StageLocation, version)
 
 	f, err := os.Open(i.RepoRoot + "/_output/release-tars/" + tgzFile)
 	if err != nil {


### PR DESCRIPTION
Have tested this change:
```
root@9111c573-288a-44ee-95eb-e750df878ea1:/home/prow/go/src/github.com/ppc64le-cloud/kubetest2-plugins# kubetest2 tf --build --repo-root=../../kubernetes/kubernetes/ --stage=cos://us-south/ppc64le-ci-builds/Upstream_CI/v1.32
I1030 06:31:53.261563   83875 app.go:61] The files in RunDir shall not be part of Artifacts
I1030 06:31:53.261595   83875 app.go:62] pass rundir-in-artifacts flag True for RunDir to be part of Artifacts
I1030 06:31:53.261611   83875 app.go:64] RunDir for this run: "/home/prow/go/src/github.com/ppc64le-cloud/kubetest2-plugins/_rundir/9111c573-288a-44ee-95eb-e750df878ea1"
I1030 06:31:53.268113   83875 app.go:136] ID for this run: "9111c573-288a-44ee-95eb-e750df878ea1"
Check if package dependencies are installed in the environment
I1030 06:31:53.576678   83875 make.go:46] running build quick-release using: KUBE_BUILD_PLATFORMS=linux/ppc64le
I1030 06:31:53.581122   83875 make.go:69] running build for test binaries
I1030 06:31:53.581361   83875 stage-ibmcos.go:63] uploading kubernetes-server-linux-ppc64le.tar.gz to location cos://us-south/ppc64le-ci-builds/Upstream_CI/v1.32/v1.32.0-alpha.3.47+daef8c2419a638
I1030 06:31:56.979912   83875 stage-ibmcos.go:82] file uploaded
root@9111c573-288a-44ee-95eb-e750df878ea1:/home/prow/go/src/github.com/ppc64le-cloud/kubetest2-plugins#
```
![image](https://github.com/user-attachments/assets/6bf72361-21e2-40a4-b577-d7dcae5802bc)
