### PR TITLE
Extend DumpClusterLogs with additional node level information

### DIFF
--- a/pkg/providers/common/provider.go
+++ b/pkg/providers/common/provider.go
@@ -3,7 +3,7 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -77,7 +77,7 @@ func (p *Provider) DumpConfig(dir string) error {
 		return fmt.Errorf("errored file converting config to json: %v", err)
 	}
 
-	err = ioutil.WriteFile(filename, config, 0644)
+	err = os.WriteFile(filename, config, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to dump the json config to: %s, err: %v", filename, err)
 	}


### PR DESCRIPTION
Fixes: #100 

Implements collection of kernel logs, running services, container runtime and dmesg, which are vital for debugging failed deployments. 

```[root@kubetest21 kubetest2-plugins]# kubetest2 tf --rundir-in-artifacts --powervs-dns k8s-tests --powervs-image-name CentOS-Stream-9 --powervs-region dal --powervs-zone dal10 --powervs-service-id 79e6e139-f6d8-46a6-819c-f5222959be99 --powervs-api-key BnioLKdNj0zCpX4qHkq38pCGq7qFbHhk2XVIHH0tAfke --powervs-ssh-key kishen-fyrevm --ssh-private-key /root/.ssh/id_rsa --build-version v1.32.0-alpha.3.43+5fcef4f79dcbb4 --workers-count 1 --cluster-name perf-test10 --playbook install-k8s-perf.yml --up --auto-approve -v 5 > perf-test-10.logs
I1104 22:09:04.392315  159955 app.go:64] RunDir for this run: "/root/kubetest2-plugins/_artifacts/_rundir/f66fbe1f-a2ef-4082-959c-9c4b60cbc2ab"
I1104 22:09:04.399017  159955 app.go:136] ID for this run: "f66fbe1f-a2ef-4082-959c-9c4b60cbc2ab"
        I1104 22:15:02.538821  159955 deployer.go:199] masters: ["150.239.19.109"]
I1104 22:15:04.633475  159955 deployer.go:199] workers: ["150.239.19.110"]
I1104 22:15:04.633561  159955 deployer.go:209] inventory: {[150.239.19.109] [150.239.19.110]}
I1104 22:15:04.634186  159955 deployer.go:234] commonJSON: {"release_marker":"ci/latest","build_version":"v1.32.0-alpha.3.43+5fcef4f79dcbb4","cluster_name":"perf-test10","apiserver_port":992,"workers_count":1,"bootstrap_token":"y478h2.b7rsqd6cvafur3n5","kubeconfig_path":"/root/kubetest2-plugins/perf-test10/kubeconfig","ssh_private_key":"/root/.ssh/id_rsa","extra_cert":"150.239.19.109"}
I1104 22:15:04.634321  159955 deployer.go:247] finalJSON with extra vars: {"apiserver_port":992,"bootstrap_token":"y478h2.b7rsqd6cvafur3n5","build_version":"v1.32.0-alpha.3.43+5fcef4f79dcbb4","cluster_name":"perf-test10","extra_cert":"150.239.19.109","kubeconfig_path":"/root/kubetest2-plugins/perf-test10/kubeconfig","release_marker":"ci/latest","ssh_private_key":"/root/.ssh/id_rsa","workers_count":1}
I1104 22:15:04.638218  159955 ansible.go:27] ansible-playbook with args: [--inventory=perf-test10/hosts --extra-vars={"apiserver_port":992,"bootstrap_token":"y478h2.b7rsqd6cvafur3n5","build_version":"v1.32.0-alpha.3.43+5fcef4f79dcbb4","cluster_name":"perf-test10","extra_cert":"150.239.19.109","kubeconfig_path":"/root/kubetest2-plugins/perf-test10/kubeconfig","release_marker":"ci/latest","ssh_private_key":"/root/.ssh/id_rsa","workers_count":1} perf-test10/install-k8s-perf.yml]
I1104 22:21:56.833863  159955 deployer.go:332] About to run: [kubectl get nodes -o=name]
I1104 22:21:57.695833  159955 deployer.go:264] cluster reported as up
I1104 22:21:57.696164  159955 deployer.go:269] Dumping cluster info..
I1104 22:21:57.696253  159955 dumplogs.go:24] Collecting cluster logs under /root/kubetest2-plugins/_artifacts/_rundir/f66fbe1f-a2ef-4082-959c-9c4b60cbc2ab/logs
I1104 22:21:57.696483  159955 dumplogs.go:48] About to run: [kubectl cluster-info dump]
I1104 22:21:59.996690  159955 dumplogs.go:58] Collecting node level information from machine 150.239.19.109
I1104 22:21:59.996846  159955 dumplogs.go:65] Remotely executing command: sudo journalctl --no-pager --output=short-precise -k
I1104 22:22:01.051693  159955 dumplogs.go:65] Remotely executing command: sudo systemctl list-units -t service --no-pager --no-legend --all
I1104 22:22:02.032341  159955 dumplogs.go:65] Remotely executing command: journalctl -xeu crio --no-pager
I1104 22:22:02.914067  159955 dumplogs.go:65] Remotely executing command: journalctl -xeu containerd --no-pager
I1104 22:22:03.968417  159955 dumplogs.go:65] Remotely executing command: dmesg
I1104 22:22:04.990696  159955 dumplogs.go:58] Collecting node level information from machine 150.239.19.110
I1104 22:22:04.990949  159955 dumplogs.go:65] Remotely executing command: sudo journalctl --no-pager --output=short-precise -k
I1104 22:22:05.981036  159955 dumplogs.go:65] Remotely executing command: sudo systemctl list-units -t service --no-pager --no-legend --all
I1104 22:22:06.934770  159955 dumplogs.go:65] Remotely executing command: journalctl -xeu crio --no-pager
I1104 22:22:07.827899  159955 dumplogs.go:65] Remotely executing command: journalctl -xeu containerd --no-pager
I1104 22:22:08.859291  159955 dumplogs.go:65] Remotely executing command: dmesg
I1104 22:22:09.857450  159955 dumplogs.go:77] Successfully collected cluster logs under /root/kubetest2-plugins/_artifacts/_rundir/f66fbe1f-a2ef-4082-959c-9c4b60cbc2ab/logs
```

```
[root@kubetest21 kubetest2-plugins]#  ls /root/kubetest2-plugins/_artifacts/_rundir/f66fbe1f-a2ef-4082-959c-9c4b60cbc2ab/logs
150.239.19.109-containerd-logs.log  150.239.19.109-kernel.log.log       150.239.19.110-crio-logs.log   150.239.19.110-services.log.log
150.239.19.109-crio-logs.log        150.239.19.109-services.log.log     150.239.19.110-dmesg.log.log   cluster-info.log
150.239.19.109-dmesg.log.log        150.239.19.110-containerd-logs.log  150.239.19.110-kernel.log.log
```

