### PR TITLE
Refine DumpClusterLogs

### DIFF
--- a/kubetest2-tf/deployer/dumplogs.go
+++ b/kubetest2-tf/deployer/dumplogs.go
@@ -13,9 +13,7 @@ import (
 )
 
 var commandFilename = map[string]string{
-	// TODO: Determine the container runtime installed on the machine, rather than iterating through all available options.
-	"crio.log":       "journalctl -xeu crio --no-pager",
-	"containerd.log": "journalctl -xeu containerd --no-pager",
+	fmt.Sprintf("%s.log", common.CommonProvider.Runtime): fmt.Sprintf("journalctl -xeu %s --no-pager", common.CommonProvider.Runtime),
 
 	"dmesg.log":    "dmesg",
 	"kernel.log":   "sudo journalctl --no-pager --output=short-precise -k",

--- a/pkg/providers/common/provider.go
+++ b/pkg/providers/common/provider.go
@@ -38,7 +38,7 @@ func (p *Provider) BindFlags(flags *pflag.FlagSet) {
 		&p.Runtime, "runtime", "", "Runtime used while installing k8s cluster",
 	)
 	flags.StringVar(
-		&p.StorageServer, "s3-server", "", "S3 server where Kubernees Bits are stored",
+		&p.StorageServer, "s3-server", "", "S3 server where Kubernetes Bits are stored",
 	)
 	flags.StringVar(
 		&p.StorageBucket, "bucket", "", "Storage Bucket",

--- a/pkg/providers/powervs/powervs.go
+++ b/pkg/providers/powervs/powervs.go
@@ -3,7 +3,7 @@ package powervs
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path"
 
 	"github.com/ppc64le-cloud/kubetest2-plugins/pkg/providers"
@@ -72,7 +72,7 @@ func (p *Provider) DumpConfig(dir string) error {
 	if err != nil {
 		return fmt.Errorf("errored file converting config to json: %v", err)
 	}
-	err = ioutil.WriteFile(filename, config, 0644)
+	err = os.WriteFile(filename, config, 0644)
 	if err != nil {
 		return fmt.Errorf("failed to dump the json config to: %s, err: %v", filename, err)
 	}


### PR DESCRIPTION
Fixes issue wherein the dump-cluster logs had failed earlier due to unavailability of matching private key. Tested locally and verified with a separate keypair.

```
I1106 04:45:20.735507  178533 dumplogs.go:44] About to run: [kubectl cluster-info dump]
I1106 04:45:23.068539  178533 dumplogs.go:62] Collecting node level information from PowerVS instance 150.240.147.60
I1106 04:45:23.068998  178533 dumplogs.go:72] Remotely executing command: [ssh -i /root/.ssh/kishen root@150.240.147.60 journalctl -xeu crio --no-pager]
I1106 04:45:23.975515  178533 dumplogs.go:72] Remotely executing command: [ssh -i /root/.ssh/kishen root@150.240.147.60 journalctl -xeu containerd --no-pager]
I1106 04:45:25.102240  178533 dumplogs.go:72] Remotely executing command: [ssh -i /root/.ssh/kishen root@150.240.147.60 dmesg]
I1106 04:45:26.138375  178533 dumplogs.go:72] Remotely executing command: [ssh -i /root/.ssh/kishen root@150.240.147.60 sudo journalctl --no-pager --output=short-precise -k]
I1106 04:45:27.200145  178533 dumplogs.go:72] Remotely executing command: [ssh -i /root/.ssh/kishen root@150.240.147.60 sudo systemctl list-units -t service --no-pager --no-legend --all]
I1106 04:45:28.204135  178533 dumplogs.go:62] Collecting node level information from PowerVS instance 150.240.147.62
I1106 04:45:28.204566  178533 dumplogs.go:72] Remotely executing command: [ssh -i /root/.ssh/kishen root@150.240.147.62 journalctl -xeu crio --no-pager]
I1106 04:45:29.102900  178533 dumplogs.go:72] Remotely executing command: [ssh -i /root/.ssh/kishen root@150.240.147.62 journalctl -xeu containerd --no-pager]
I1106 04:45:30.136908  178533 dumplogs.go:72] Remotely executing command: [ssh -i /root/.ssh/kishen root@150.240.147.62 dmesg]
I1106 04:45:31.155472  178533 dumplogs.go:72] Remotely executing command: [ssh -i /root/.ssh/kishen root@150.240.147.62 sudo journalctl --no-pager --output=short-precise -k]
I1106 04:45:32.175227  178533 dumplogs.go:72] Remotely executing command: [ssh -i /root/.ssh/kishen root@150.240.147.62 sudo systemctl list-units -t service --no-pager --no-legend --all]
I1106 04:45:33.260730  178533 dumplogs.go:90] Successfully collected cluster logs under /root/kubetest2-plugins/_artifacts/_rundir/e7193f94-cee1-4c34-bc70-3e677b11a6d1/logs
```

Edit: Further changed logic to continue on errors to collect more information from the endpoints.
``` 
Dumping cluster logs at the end of Up() failed: Observed one or more errors while collecting logs: [Failed to collect logs from node - [ssh -i /root/.ssh/kishen root@150.239.19.94 dmesgi] - bash: line 1: dmesgi: command not found
, err: exit status 127 Failed to collect logs from node - [ssh -i /root/.ssh/kishen root@150.239.19.93 dmesgi] - bash: line 1: dmesgi: command not found
```
