### PR TITLE
Initialize the CR logs command-pair during runtime

### DIFF
--- a/kubetest2-tf/deployer/dumplogs.go
+++ b/kubetest2-tf/deployer/dumplogs.go
@@ -13,15 +13,17 @@ import (
 )
 
 var commandFilename = map[string]string{
-	fmt.Sprintf("%s.log", common.CommonProvider.Runtime): fmt.Sprintf("journalctl -xeu %s --no-pager", common.CommonProvider.Runtime),
-
-	"dmesg.log":    "dmesg",
-	"kernel.log":   "sudo journalctl --no-pager --output=short-precise -k",
-	"services.log": "sudo systemctl list-units -t service --no-pager --no-legend --all"}
+	"dmesg":    "dmesg",
+	"kernel":   "sudo journalctl --no-pager --output=short-precise -k",
+	"services": "sudo systemctl list-units -t service --no-pager --no-legend --all"}
 
 func (d *deployer) DumpClusterLogs() error {
 	var errors []error
 	var stdErr, stdOut bytes.Buffer
+
+	// Set exclusively as maps are declared during compile-time and may be set with defaults.
+	commandFilename[common.CommonProvider.Runtime] = fmt.Sprintf("journalctl -xeu %s --no-pager", common.CommonProvider.Runtime)
+
 	klog.Infof("Collecting cluster logs under %s", d.logsDir)
 	// create a directory based on the generated path: _rundir/dump-cluster-logs
 	if _, err := os.Stat(d.logsDir); os.IsNotExist(err) {

--- a/pkg/providers/common/provider.go
+++ b/pkg/providers/common/provider.go
@@ -35,7 +35,7 @@ func (p *Provider) BindFlags(flags *pflag.FlagSet) {
 		&p.BuildVersion, "build-version", "", "Kubernetes Build Version",
 	)
 	flags.StringVar(
-		&p.Runtime, "runtime", "", "Runtime used while installing k8s cluster",
+		&p.Runtime, "runtime", "containerd", "Runtime used while installing k8s cluster",
 	)
 	flags.StringVar(
 		&p.StorageServer, "s3-server", "", "S3 server where Kubernetes Bits are stored",


### PR DESCRIPTION
It was observed that the container runtime logs didn't capture any information as the maps were defied during build time. This PR is to initialise the map with the command to execute, during the plugin's runtime to avoid being set to an empty value. 

Additionally, the default runtime is set to containerd. This change doesn't have much of an impact as the same is re-defaulted in the k8s-ansible repository. This enables containerd logs(if set-up) to be captured. 