### PR TITLE
Move logs under artifacts

### DIFF
--- a/kubetest2-tf/deployer/deployer.go
+++ b/kubetest2-tf/deployer/deployer.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/kubetest2/pkg/artifacts"
 	"sigs.k8s.io/kubetest2/pkg/types"
 
 	"github.com/ppc64le-cloud/kubetest2-plugins/kubetest2-tf/deployer/options"
@@ -121,7 +122,7 @@ var _ types.Deployer = &deployer{}
 func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 	d := &deployer{
 		commonOptions: opts,
-		logsDir:       filepath.Join(opts.RunDir(), "logs"),
+		logsDir:       filepath.Join(artifacts.BaseDir(), "logs"),
 		BuildOptions: &options.BuildOptions{
 			CommonBuildOptions: &build.Options{
 				Builder:         &build.NoopBuilder{},

--- a/kubetest2-tf/deployer/dumplogs.go
+++ b/kubetest2-tf/deployer/dumplogs.go
@@ -63,6 +63,8 @@ func (d *deployer) DumpClusterLogs() error {
 	for _, machineIP := range d.machineIPs {
 		klog.Infof("Collecting node level information from PowerVS instance %s", machineIP)
 		for logFile, command := range commandFilename {
+			stdOut.Reset()
+			stdErr.Reset()
 			commandArgs := []string{
 				"ssh",
 				"-i",
@@ -85,6 +87,7 @@ func (d *deployer) DumpClusterLogs() error {
 				errors = append(errors, fmt.Errorf("Failed to create a log-file: %v", err))
 				continue
 			} else {
+				outfile.WriteString(string(stdOut.Bytes()))
 				outfile.Close()
 			}
 		}


### PR DESCRIPTION
Fixes:
1. Empty log file for respective components.
2. Creating directory under _artifacts for avoiding uploading the _rundir

```I1107 00:41:55.457056  200060 dumplogs.go:27] Collecting cluster logs under /root/kubetest2-plugins/_artifacts/logs
I1107 00:41:55.457106  200060 dumplogs.go:45] About to run: [kubectl cluster-info dump]
I1107 00:42:00.025368  200060 dumplogs.go:64] Collecting node level information from PowerVS instance 150.240.145.228
I1107 00:42:00.025425  200060 dumplogs.go:75] Remotely executing command: [ssh -i /root/.ssh/kishen root@150.240.145.228 dmesg]
I1107 00:42:01.277571  200060 dumplogs.go:75] Remotely executing command: [ssh -i /root/.ssh/kishen root@150.240.145.228 sudo journalctl --no-pager --output=short-precise -k]
I1107 00:42:02.286427  200060 dumplogs.go:75] Remotely executing command: [ssh -i /root/.ssh/kishen root@150.240.145.228 sudo systemctl list-units -t service --no-pager --no-legend --all]
I1107 00:42:03.196091  200060 dumplogs.go:75] Remotely executing command: [ssh -i /root/.ssh/kishen root@150.240.145.228 journalctl -xeu containerd --no-pager]
I1107 00:42:04.202346  200060 dumplogs.go:64] Collecting node level information from PowerVS instance 150.240.145.227
I1107 00:42:04.202392  200060 dumplogs.go:75] Remotely executing command: [ssh -i /root/.ssh/kishen root@150.240.145.227 dmesg]
I1107 00:42:05.485518  200060 dumplogs.go:75] Remotely executing command: [ssh -i /root/.ssh/kishen root@150.240.145.227 sudo journalctl --no-pager --output=short-precise -k]
I1107 00:42:06.504498  200060 dumplogs.go:75] Remotely executing command: [ssh -i /root/.ssh/kishen root@150.240.145.227 sudo systemctl list-units -t service --no-pager --no-legend --all]
I1107 00:42:07.444307  200060 dumplogs.go:75] Remotely executing command: [ssh -i /root/.ssh/kishen root@150.240.145.227 journalctl -xeu containerd --no-pager]
I1107 00:42:08.499815  200060 dumplogs.go:98] Successfully collected cluster logs under /root/kubetest2-plugins/_artifacts/logs
```
Relevant logs with non-0 byte content
```
[root@kubetest21 logs]# ls -ltra
total 1280
drwxr-xr-x 3 root root     63 Nov  7 00:41 ..
-rw-r--r-- 1 root root 800641 Nov  7 00:42 cluster-info.log
-rw-r--r-- 1 root root  49398 Nov  7 00:42 150.240.145.228-dmesg.log
-rw-r--r-- 1 root root  67475 Nov  7 00:42 150.240.145.228-kernel.log
-rw-r--r-- 1 root root  12292 Nov  7 00:42 150.240.145.228-services.log
-rw-r--r-- 1 root root  70317 Nov  7 00:42 150.240.145.228-containerd.log
-rw-r--r-- 1 root root  49409 Nov  7 00:42 150.240.145.227-dmesg.log
-rw-r--r-- 1 root root  67562 Nov  7 00:42 150.240.145.227-kernel.log
-rw-r--r-- 1 root root  12292 Nov  7 00:42 150.240.145.227-services.log
-rw-r--r-- 1 root root 149452 Nov  7 00:42 150.240.145.227-containerd.log
drwxr-xr-x 2 root root   4096 Nov  7 00:42 .
```

Post merge - The following PR can be merged.
https://github.com/ppc64le-cloud/test-infra/pull/498