### PR TITLE
remove verbose option for the go build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ BUILD_FLAGS=-trimpath -ldflags="-buildid= -X=github.com/ppc64le-cloud/kubetest2-
 
 install-deployer-tf:
 	git submodule update --init
-	go build -v $(BUILD_FLAGS) -o $(OUT_DIR)/$(BINARY_NAME) $(BINARY_PATH)
+	go build $(BUILD_FLAGS) -o $(OUT_DIR)/$(BINARY_NAME) $(BINARY_PATH)
 	$(INSTALL) -d $(INSTALL_DIR)
 	$(INSTALL) $(OUT_DIR)/$(BINARY_NAME) $(INSTALL_DIR)/$(BINARY_NAME)
 .PHONY: install-deployer-tf


### PR DESCRIPTION
This verbose option is flooding the logs with additional 2000 lines of code to every prow job which uses this tool, hence removing this option which is not required will save us the space in the s3 bucket we are pushing the logs.