### PR TITLE
Update reference commands and some cleanup.

### DIFF
--- a/pkg/ansible/ansible.go
+++ b/pkg/ansible/ansible.go
@@ -2,16 +2,17 @@ package ansible
 
 import (
 	"fmt"
-	"k8s.io/klog/v2"
 	"os"
 	goexec "os/exec"
 	"path/filepath"
+
+	"k8s.io/klog/v2"
 
 	"github.com/ppc64le-cloud/kubetest2-plugins/data"
 )
 
 const (
-	ansibleDataDir    = "k8s-ansible"
+	ansibleDataDir = "k8s-ansible"
 )
 
 func Playbook(dir, inventory, extraVars, playbook string) (int, error) {
@@ -44,9 +45,5 @@ func Playbook(dir, inventory, extraVars, playbook string) (int, error) {
 }
 
 func unpackAnsible(dir string) error {
-	err := data.Unpack(dir, ansibleDataDir)
-	if err != nil {
-		return err
-	}
-	return nil
+	return data.Unpack(dir, ansibleDataDir)
 }

--- a/pkg/providers/powervs/powervs.go
+++ b/pkg/providers/powervs/powervs.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"path"
 
+	"github.com/spf13/pflag"
+
 	"github.com/ppc64le-cloud/kubetest2-plugins/pkg/providers"
 	"github.com/ppc64le-cloud/kubetest2-plugins/pkg/tfvars/powervs"
-	"github.com/spf13/pflag"
 )
 
 const (
@@ -50,10 +51,10 @@ func (p *Provider) BindFlags(flags *pflag.FlagSet) {
 		&p.ServiceID, "powervs-service-id", "", "IBM Cloud PowerVS service instance ID(get GUID from command: ibmcloud resource service-instances --long)",
 	)
 	flags.StringVar(
-		&p.NetworkName, "powervs-network-name", "", "Network Name(command: ibmcloud pi nets)",
+		&p.NetworkName, "powervs-network-name", "", "Network Name(command: ibmcloud pi subnet ls)",
 	)
 	flags.StringVar(
-		&p.ImageName, "powervs-image-name", "", "Image ID(command: ibmcloud pi imgs)",
+		&p.ImageName, "powervs-image-name", "", "Image ID(command: ibmcloud pi img ls)",
 	)
 	flags.Float64Var(
 		&p.Memory, "powervs-memory", 8, "Memory in GBs",


### PR DESCRIPTION
Changes:
1. Groups imports.
2. Update to latest command references:

Networks:
```
Current:

ET@cloudshell:~$ ibmcloud pi nets
Error: unknown command "nets" for "pi"
Run 'pi --help' for usage.


Updated:
ET@cloudshell:~$ ibmcloud pi subnet ls
Listing subnets under account PCLOUD Upstream CI as user ET...
ID                                     Name                                  Address
1fdd6941-d58b-4a69-9d6e-network   public-192_168_235_128-29-VLAN_2176   /pcloud/v1/cloud-instances/XX/networks/XX
```
Images:
```
Current:

ET@cloudshell:~$ ibmcloud pi imgs
Error: unknown command "imgs" for "pi"

Did you mean this?
        image

Run 'pi --help' for usage.


Updated:

ET@cloudshell:~$ ibmcloud pi img ls
Listing images under account PCLOUD Upstream CI as user ET...
ID                                     Name              Address
f59ab5b3-f148-4abf-acde-image   CentOS-Stream-9   /pcloud/v1/cloud-instances/XX/images/XX

```