### PR TITLE
Update to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,9 @@
 module github.com/ppc64le-cloud/kubetest2-plugins
 
-go 1.23
+go 1.23.0
+
+toolchain go1.23.3
+
 require (
 	github.com/IBM/ibm-cos-sdk-go v1.12.1
 	github.com/octago/sflags v0.3.1


### PR DESCRIPTION
After https://github.com/ppc64le-cloud/kubetest2-plugins/pull/216/commits/30e86ee5ee78275b0203232bd438b0a070c5457b, below is the Error:

```
[root@raji-x86-workspace1 kubetest2-plugins]# make install-deployer-tf
git submodule update --init
go build -trimpath -ldflags="-buildid= -X=github.com/ppc64le-cloud/kubetest2-plugins/kubetest2-tf/deployer.GitTag=30e86ee" -o /root/kubetest2-plugins/bin/kubetest2-tf ./kubetest2-tf
go: updates to go.mod needed; to update it:
        go mod tidy
make: *** [Makefile:22: install-deployer-tf] Error 1
[root@raji-x86-workspace1 kubetest2-plugins]# 
```